### PR TITLE
Randomize planets, fps and asteroid counter

### DIFF
--- a/main.py
+++ b/main.py
@@ -185,12 +185,14 @@ def setPlanets(num_planets):
 def arePlanetsTooClose(planets, spread_distance):
     for planet_a, planet_b in itertools.combinations(planets, 2):
         average_mass = (planet_a.mass + planet_b.mass) / 2
-        if planet_a.pos.distance_to(planet_b.pos) < spread_distance + average_mass:
+        if planet_a.pos.distance_to(planet_b.pos) < spread_distance + (
+            average_mass / 2
+        ):
             return True
 
 
 g = Game()
-num_planets = 6
+num_planets = 10
 planets = setPlanets(num_planets)
 pobjects = Objects()
 graviton = 2

--- a/main.py
+++ b/main.py
@@ -1,5 +1,8 @@
 import pygame
 import random
+import itertools
+
+SPREAD_COMPRESSOR = 100
 
 test = "testing git"
 
@@ -46,17 +49,32 @@ class Game:
 
             if event.type == pygame.KEYDOWN:
                 if event.key == pygame.K_w:
-                    earth.mass += 5
-                    print(earth.mass)
+                    planet.mass += 5
+                    print(planet.mass)
                 if event.key == pygame.K_s:
-                    earth.mass -= 5
-                    print(earth.mass)
+                    planet.mass -= 5
+                    print(planet.mass)
+                if event.key == pygame.K_r:
+                    g.run = False
+                    pobjects.objects = []
 
     def update(self):
+        font_size = 40
+        font = pygame.font.SysFont("Arial", font_size)
+
+        num_asteroids = font.render(
+            f"Number of asteroids: {len(pobjects.objects)}", True, "white"
+        )
+        num_asteroids_rect = num_asteroids.get_rect(center=(self.width / 2, 50))
+        pygame.Surface.blit(self.window, num_asteroids, num_asteroids_rect)
+
+        fps = font.render(f"FPS: {int(self.clock.get_fps())}", True, "white")
+        fps_rect = fps.get_rect(center=(150, 50))
+        pygame.Surface.blit(self.window, fps, fps_rect)
         pygame.display.update()
 
     def render(self):
-        if self.spawning == True:
+        if self.spawning is True:
             pygame.draw.circle(g.window, "blue", self.start_point, 10, 0)
             pygame.draw.line(
                 g.window, "blue", self.start_point, pygame.mouse.get_pos(), 2
@@ -79,19 +97,32 @@ class Objects:
 
 
 class Planet:
-    def __init__(self, x, y, color="grey", mass=100):
-        self.x = x
-        self.y = y
-        self.pos = pygame.Vector2(x, y)
+    def __init__(self, color="grey", mass=100):
         self.mass = mass
         self.velocity = 0
         self.color = color
+        self.x = clamp(
+            g.width / generateRandomPosition(),
+            mass,
+            g.width - mass,
+        )
+        self.y = clamp(
+            g.height / generateRandomPosition(),
+            mass,
+            g.height - mass,
+        )
+        self.pos = pygame.Vector2(self.x, self.y)
 
     def update(self):
         self.pos = pygame.Vector2(self.x, self.y)
 
     def render(self):
-        pygame.draw.circle(g.window, self.color, self.pos, 50, 0)
+        pygame.draw.circle(g.window, self.color, self.pos, self.mass / 2, 0)
+        font_size = 40
+        font = pygame.font.SysFont("Arial", font_size)
+        text = font.render(str(self.mass), True, "white")
+        text_rect = text.get_rect(center=(self.pos[0], self.pos[1]))
+        pygame.Surface.blit(g.window, text, text_rect)
 
 
 class Asteroid:
@@ -102,14 +133,14 @@ class Asteroid:
         self.acceleration = pygame.Vector2(0, 0)
 
     def update(self):
-        gravity = earth.pos - self.pos
+        gravity = planet.pos - self.pos
         distance = gravity.magnitude()
 
         if distance > 50:
             distance = 50
         elif distance < 25:
             distance = 25
-        grav_m = (graviton * self.mass * earth.mass) / (distance * distance)
+        grav_m = (graviton * self.mass * planet.mass) / (distance * distance)
         gravity = gravity.normalize()
         gravity = gravity * grav_m
 
@@ -123,26 +154,66 @@ class Asteroid:
         pygame.draw.line(g.window, "green", self.pos, self.pos + self.velocity * 5, 2)
 
 
+def generateRandomPosition():
+    return round(random.uniform(1, 4), 2)
+
+
+def generateRandomMass():
+    return random.randrange(75, 200, 25)
+
+
+def generateRandomColor():
+    return (random.randrange(256), random.randrange(256), random.randrange(256))
+
+
+def clamp(n, minn, maxn):
+    return max(min(maxn, n), minn)
+
+
+def setPlanets(num_planets):
+    output_planets = []
+    for i in range(num_planets):
+        output_planets.append(
+            Planet(
+                color=generateRandomColor(),
+                mass=generateRandomMass(),
+            )
+        )
+    return output_planets
+
+
+def arePlanetsTooClose(planets, spread_distance):
+    for planet_a, planet_b in itertools.combinations(planets, 2):
+        average_mass = (planet_a.mass + planet_b.mass) / 2
+        if planet_a.pos.distance_to(planet_b.pos) < spread_distance + average_mass:
+            return True
+
+
 g = Game()
-earths = [
-    Planet(g.width / 4, g.height / 2, "blue", mass=150),
-    Planet(g.width / 1.25, g.height / 2, "red", mass=75),
-    Planet(g.width / 2, g.height / 2),
-]
+num_planets = 6
+planets = setPlanets(num_planets)
 pobjects = Objects()
 graviton = 2
+
+spread_distance = SPREAD_COMPRESSOR * (num_planets / max(1, num_planets - 1))
 
 while g.run:
     g.input()
     g.window.fill("black")
     g.render()
 
-    for earth in earths:
-        earth.update()
-        earth.render()
+    while arePlanetsTooClose(planets, spread_distance):
+        planets = setPlanets(num_planets)
+
+    for planet in planets:
+        planet.update()
+        planet.render()
 
         pobjects.update()
         pobjects.render()
 
     g.update()
     g.clock.tick(60)
+    if g.run is False:
+        planets = setPlanets(num_planets)
+        g.run = True


### PR DESCRIPTION
- Randomization of planet positions and masses and colors
- Mass of planets displayed inside planet
- Planet position check to ensure no overlaps, and none are touching the sides. 
    - Change `SPREAD_COMPRESSOR` to adjust how close they can be. 
    - A spread of zero should still prevent most overlapping
    - Maximum number of planets seems to be 12 with the spread set to 100.
- FPS and number of asteroids display
- Press `r` to reset the simulation